### PR TITLE
Use the brightness data from the data stream instead of the fixed 31

### DIFF
--- a/plasma.cpp
+++ b/plasma.cpp
@@ -57,6 +57,7 @@ void plasma_flip() {
     Multiverse is B G R _
     */
     for(auto x = 0u; x < sizeof(led_buffer); x += 4) {
+        led_buffer[x + 0] = APA102_SOF | led_front_buffer[x + 3];
         led_buffer[x + 1] = led_front_buffer[x + 0];
         led_buffer[x + 2] = led_front_buffer[x + 1];
         led_buffer[x + 3] = led_front_buffer[x + 2];


### PR DESCRIPTION
The APA102 leds support brightness, the plasma data stream supports brightness, all the code supports brightness, except for the flip() function that just used the Start-of-frame marker plus 31  from the initialisation.

This single line fixes that.